### PR TITLE
fix: added class instance vars to inherited class

### DIFF
--- a/lib/discorb/sticker.rb
+++ b/lib/discorb/sticker.rb
@@ -51,6 +51,15 @@ module Discorb
       # @!attribute [r] guild
       #   @macro client_cache
       #   @return [Discorb::Guild] The guild the sticker is in.
+      @sticker_type = {
+        1 => :official,
+        2 => :guild,
+      }.freeze
+      @sticker_format = {
+        1 => :png,
+        2 => :apng,
+        3 => :lottie,
+      }
 
       def guild
         @client.guilds[@guild_id]


### PR DESCRIPTION
## What does this PR do?
adds class instance variables to `GuildSticker` from `Sticker`, as they aren't inherited

## Information

- [ X] This PR fixes an issue.
- [ ] This PR adds a new feature.
- [ ] This PR refactors code.
- [ ] This PR has breaking changes.
- [ ] This PR **won't** change the behavior of the code. (e.g. documentation)
<!-- If you need to add more information, please add it here. -->


## Checklist

- [ X] I have reviewed the code and it is clean and well documented.
- [ X] I have ran bot and it is working as expected.
- [ ] I have updated the document.

## Related issues

<!--
If there are any related issues, please add them here.
If there are no related issues, please write `None`.
-->
