### PR TITLE
Fix: message expander example

### DIFF
--- a/examples/extension/message_expander.rb
+++ b/examples/extension/message_expander.rb
@@ -10,7 +10,7 @@ class MessageExpander
 
   MESSAGE_PATTERN = Regexp.new(
     '(?!<)https://(?:ptb\.|canary\.)?discord(?:app)?\.com/channels/' \
-    "(?<guild>[0-9]{18})/(?<channel>[0-9]{18})/(?<message>[0-9]{18,19})(?!>)"
+    "(?<guild>[0-9]{17,19})/(?<channel>[0-9]{17,19})/(?<message>[0-9]{17,19})(?!>)"
   )
 
   event :message do |message|

--- a/examples/extension/message_expander.rb
+++ b/examples/extension/message_expander.rb
@@ -10,7 +10,7 @@ class MessageExpander
 
   MESSAGE_PATTERN = Regexp.new(
     '(?!<)https://(?:ptb\.|canary\.)?discord(?:app)?\.com/channels/' \
-    "(?<guild>[0-9]{18})/(?<channel>[0-9]{18})/(?<message>[0-9]{18})(?!>)"
+    "(?<guild>[0-9]{18})/(?<channel>[0-9]{18})/(?<message>[0-9]{18,19})(?!>)"
   )
 
   event :message do |message|
@@ -23,7 +23,7 @@ class MessageExpander
       begin
         url_message = ch.fetch_message(match[:message]).wait
       rescue Discorb::NotFoundError
-        url_message.add_reaction(Discorb::UnicodeEmoji["x"])
+        message.add_reaction(Discorb::UnicodeEmoji["x"])
       else
         embed = Discorb::Embed.new(
           nil, url_message.content,


### PR DESCRIPTION
## What does this PR do?

2 minor fixes:

Fix: Changed the MESSAGE_PATTERN Regexp to allow for both 18 and 19 digits message ID, as pointed out by Nanashi on the discorb server.

Fix: In case of `Discorb::NotFoundError`, original code would try to add a reaction to the unresolved messaged. I changed it to add the reaction to the triggering message instead (I assume this was the intended behaviour).



## Information

- [X] This PR fixes an issue.
- [  ] This PR adds a new feature.
- [  ] This PR refactors code.
- [  ] This PR has breaking changes.
- [  ] This PR **won't** change the behavior of the code. (e.g. documentation)
<!-- If you need to add more information, please add it here. -->


## Checklist

- [  ] I have reviewed the code and it is clean and well documented.
- [X] I have ran bot and it is working as expected.
- [  ] I have updated the document.

## Related issues

<!--
If there are any related issues, please add them here.
If there are no related issues, please write `None`.
-->
