### PR TITLE
Moved to_h and removed unnecessary array slicing

### DIFF
--- a/lib/discorb/client.rb
+++ b/lib/discorb/client.rb
@@ -586,10 +586,10 @@ module Discorb
         main_loop(nil)
       else
         @shards =
-          shards.to_h.with_index do |shard, i|
+          shards.each_with_index.to_h do |shard, i|
             [shard, Shard.new(self, shard, shard_count, i)]
           end
-        @shards.values[..-1].each_with_index do |shard, i|
+        @shards.values.each_with_index do |shard, i|
           shard.next_shard = @shards.values[i + 1]
         end
         @shards.each_value { |s| s.thread.join }


### PR DESCRIPTION
## What does this PR do?

Corrects application of to_h by moving it after the enumerator method to avoid raising a TypeError. Also removed unnecessary array slicing.

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds a new feature.
- [x] This PR refactors code.
- [ ] This PR has breaking changes.
- [ ] This PR **won't** change the behavior of the code. (e.g. documentation)

## Checklist

- [x] I have reviewed the code and it is clean and well documented.
- [x] I have ran bot and it is working as expected.
- [ ] I have updated the document.

## Related issues

None
