### PR TITLE
Fix: Correct #close! to #close

### DIFF
--- a/lib/discorb/error.rb
+++ b/lib/discorb/error.rb
@@ -98,7 +98,7 @@ module Discorb
   class CloudFlareBanError < HTTPError
     def initialize(_resp, client)
       @client = client
-      @client.close!
+      @client.close
       message = <<~MESSAGE
         The client is banned from CloudFlare.
         Hint: Try to decrease the number of requests per second, e.g. Use sleep in between requests.


### PR DESCRIPTION
## What does this PR do?

Fixes NoMethodError resulting from #close! being called in error.rb instead of the correct method #close.

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds a new feature.
- [ ] This PR refactors code.
- [ ] This PR has breaking changes.
- [ ] This PR **won't** change the behavior of the code. (e.g. documentation)
<!-- If you need to add more information, please add it here. -->


## Checklist

- [ ] I have reviewed the code and it is clean and well documented.
- [ ] I have ran bot and it is working as expected.
- [ ] I have updated the document.

## Related issues
None
